### PR TITLE
Refactor global state management to use useEffect on-mount globalReducer

### DIFF
--- a/src/front/pages/Home.jsx
+++ b/src/front/pages/Home.jsx
@@ -1,36 +1,10 @@
-import React, { useEffect } from "react"
+import React from "react"
 import rigoImageUrl from "../assets/img/rigo-baby.jpg";
 import useGlobalReducer from "../hooks/useGlobalReducer.jsx";
 
 export const Home = () => {
 
-	const { store, dispatch } = useGlobalReducer()
-
-	const loadMessage = async () => {
-		try {
-			const backendUrl = import.meta.env.VITE_BACKEND_URL
-
-			if (!backendUrl) throw new Error("VITE_BACKEND_URL is not defined in .env file")
-
-			const response = await fetch(backendUrl + "/api/hello")
-			const data = await response.json()
-
-			if (response.ok) dispatch({ type: "set_hello", payload: data.message })
-
-			return data
-
-		} catch (error) {
-			if (error.message) throw new Error(
-				`Could not fetch the message from the backend.
-				Please check if the backend is running and the backend port is public.`
-			);
-		}
-
-	}
-
-	useEffect(() => {
-		loadMessage()
-	}, [])
+	const { store } = useGlobalReducer()
 
 	return (
 		<div className="text-center mt-5">


### PR DESCRIPTION
This pull request includes several changes to improve the state management and code structure in the `useGlobalReducer` hook and the `Home` component. The most important changes include adding new hooks to the `useGlobalReducer` file and refactoring the `Home` component to remove redundant code.

Improvements to state management:

* [`src/front/hooks/useGlobalReducer.jsx`](diffhunk://#diff-4637aff1bb823042bc3beb79c0466f99c083be1d3aa15ae8e3a5331e617ac8ebL2-R2): Added `useEffect` and `useCallback` hooks to manage side effects and memoize the `loadMessage` function, which fetches a message from the backend and updates the state. [[1]](diffhunk://#diff-4637aff1bb823042bc3beb79c0466f99c083be1d3aa15ae8e3a5331e617ac8ebL2-R2) [[2]](diffhunk://#diff-4637aff1bb823042bc3beb79c0466f99c083be1d3aa15ae8e3a5331e617ac8ebR14-R43)

Code structure improvements:

* [`src/front/pages/Home.jsx`](diffhunk://#diff-6928e383c941428ae95f40b916eaf71681bb394d1d9bb3aece8b05e17ecdc431L1-R7): Removed the `useEffect` and `loadMessage` function from the `Home` component, as the message loading logic is now handled in the `useGlobalReducer` hook. This simplifies the component and avoids redundant code.