### PR TITLE
static route update in app.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,7 @@ from api.commands import setup_commands
 
 ENV = "development" if os.getenv("FLASK_DEBUG") == "1" else "production"
 static_file_dir = os.path.join(os.path.dirname(
-    os.path.realpath(__file__)), '../public/')
+    os.path.realpath(__file__)), '../dist/')
 app = Flask(__name__)
 app.url_map.strict_slashes = False
 


### PR DESCRIPTION
Al llevar a producción, el bundle se está generando en la carpeta dist, pero actualmente el proyecto busca los archivos estáticos en la carpeta public. Para corregir esto, se ha actualizado la ruta de los archivos estáticos en app.py, asegurando que el proyecto los encuentre correctamente.