### PR TITLE
Keep the footer at the bottom of any page ALWAYS

### DIFF
--- a/src/front/pages/Layout.jsx
+++ b/src/front/pages/Layout.jsx
@@ -7,7 +7,7 @@ import { Footer } from "../components/Footer"
 export const Layout = () => {
     return (
         <ScrollToTop>
-            <div className="d-flex flex-column" style={{height: '100vh'}}>
+            <div className="d-flex flex-column" style={{minHeight: '100vh'}}>
                 <Navbar />
                     <Outlet />
                 <Footer />

--- a/src/front/pages/Layout.jsx
+++ b/src/front/pages/Layout.jsx
@@ -7,9 +7,11 @@ import { Footer } from "../components/Footer"
 export const Layout = () => {
     return (
         <ScrollToTop>
-            <Navbar />
-                <Outlet />
-            <Footer />
+            <div className="d-flex flex-column" style={{height: '100vh'}}>
+                <Navbar />
+                    <Outlet />
+                <Footer />
+            </div>
         </ScrollToTop>
     )
 }


### PR DESCRIPTION
This change makes sure the footer is always at the very bottom of the page as it should be