### PR TITLE
Update vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,6 @@ export default defineConfig({
         port: 3000
     },
     build: {
-        outDir: 'dist'
+        outDir: 'public'
     }
 })


### PR DESCRIPTION
para evitar el error que al desplegar muestre la pagina por defecto (hello rigo) hay que ponerle que el build lo haga a public